### PR TITLE
Formarray bug

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ export function testFormReducer(state: any = { form1: {}, form2: { value: { item
         form2: {
           ...state.form2,
           value: {
-            items: !!!state.form2.value.items ? [{}] : [...state.form2.value.items, {}]
+            items: !!!state.form2.value.items ? [{}] : [...state.form2.value.items, { name: 'testj'}]
           }
         }
       };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,19 @@
-import {BrowserModule} from '@angular/platform-browser';
-import {NgModule} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
 
-import {AppComponent} from './app.component';
-import {StoreFormsModule} from '../lib/store-forms.module';
-import {ReactiveFormsModule} from '@angular/forms';
-import {Action, StoreModule} from '@ngrx/store';
-import {StoreDevtoolsModule} from '@ngrx/store-devtools';
-import {storeFormsMetaReducer} from '../lib/reducer';
-import {Form1ContainerComponent} from './container/form1-container.component';
-import {Form1Component} from './components/form1.component';
-import {EffectsModule} from '@ngrx/effects';
-import {StoreFormsEffects} from '../lib/effects';
+import { AppComponent } from './app.component';
+import { StoreFormsModule } from '../lib/store-forms.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Action, StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
+import { storeFormsMetaReducer } from '../lib/reducer';
+import { Form1ContainerComponent } from './container/form1-container.component';
+import { Form1Component } from './components/form1.component';
+import { EffectsModule } from '@ngrx/effects';
+import { StoreFormsEffects } from '../lib/effects';
+import { FormArrayComponent } from './components/form-array.component';
 
-export function testFormReducer(state: any = {form1: {}}, action: Action) {
+export function testFormReducer(state: any = { form1: {}, form2: { value: { items: [] } } }, action: Action) {
   switch (action.type) {
     case 'CustomUpdateAction': {
       return {
@@ -22,6 +23,17 @@ export function testFormReducer(state: any = {form1: {}}, action: Action) {
           value: {
             ...state.form1.value,
             name: 'Custom reset'
+          }
+        }
+      };
+    }
+    case 'AddFormArrayItemAction': {
+      return {
+        ...state,
+        form2: {
+          ...state.form2,
+          value: {
+            items: !!!state.form2.value.items ? [{}] : [...state.form2.value.items, {}]
           }
         }
       };
@@ -36,7 +48,8 @@ export function testFormReducer(state: any = {form1: {}}, action: Action) {
   declarations: [
     AppComponent,
     Form1ContainerComponent,
-    Form1Component
+    Form1Component,
+    FormArrayComponent
   ],
   imports: [
     BrowserModule,
@@ -44,8 +57,8 @@ export function testFormReducer(state: any = {form1: {}}, action: Action) {
     StoreModule.forRoot({
       testForm: testFormReducer
     }, {
-      metaReducers: [storeFormsMetaReducer]
-    }),
+        metaReducers: [storeFormsMetaReducer]
+      }),
     StoreDevtoolsModule.instrument(),
     EffectsModule.forRoot([
       StoreFormsEffects

--- a/src/app/components/form-array.component.html
+++ b/src/app/components/form-array.component.html
@@ -1,0 +1,10 @@
+<form [formGroup]="formGroup" rxsfBinding="testForm.form2">
+  <!-- <ng-container formArrayName="items">
+    <ul *ngFor="let item of formGroup.get('items').controls; let i = index">
+      <ng-container [formGroupName]="i">
+        <li><input type="text" formControlName="name"></li>
+      </ng-container>
+    </ul>
+  </ng-container> -->
+</form>
+<button type="button" (click)="addFormArrayItem.emit()">Add item to array</button>

--- a/src/app/components/form-array.component.ts
+++ b/src/app/components/form-array.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'rxsf-form-array',
+  templateUrl: './form-array.component.html',
+  styleUrls: ['./form-array.component.css']
+})
+export class FormArrayComponent implements OnInit {
+  @Input() public formGroup: FormGroup;
+  @Output() public addFormArrayItem = new EventEmitter();
+  constructor() { }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/container/form1-container.component.html
+++ b/src/app/container/form1-container.component.html
@@ -1,5 +1,8 @@
-<rxsf-form1 [formGroup]="formGroup"
-            [formState]="formState | async">
+<rxsf-form1 [formGroup]="formGroup" [formState]="formState | async">
 </rxsf-form1>
 <button (click)="reset()">Reset</button>
 <button (click)="resetCustom()">Custom Reset</button>
+
+<hr>
+<h2>Form array</h2>
+<rxsf-form-array [formGroup]="formArrayGroup" (addFormArrayItem)="addFormArrayItem()"></rxsf-form-array>

--- a/src/app/container/form1-container.component.ts
+++ b/src/app/container/form1-container.component.ts
@@ -47,7 +47,7 @@ export class Form1ContainerComponent {
     //     const items = <any>result.value.items;
     //     const controls = !!!items ? [] : items.map(item => {
     //       return this.fb.group({
-    //         name: ['']
+    //         name: [item.name]
     //       });
     //     });
     //     this.formArrayGroup.setControl('items', this.fb.array(controls));

--- a/src/app/container/form1-container.component.ts
+++ b/src/app/container/form1-container.component.ts
@@ -1,14 +1,18 @@
-import {Component} from '@angular/core';
-import {FormGroupState} from '../../lib/model';
-import {AbstractControl, FormBuilder, FormGroup, Validators} from '@angular/forms';
-import {Action, Store} from '@ngrx/store';
-import {Observable} from 'rxjs/Observable';
-import {of} from 'rxjs/observable/of';
-import {delay} from 'rxjs/operators';
-import {UpdateStoreFormAction} from '../../lib/reducer';
+import { Component } from '@angular/core';
+import { FormGroupState } from '../../lib/model';
+import { AbstractControl, FormBuilder, FormGroup, Validators, FormArray } from '@angular/forms';
+import { Action, Store } from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { delay, filter } from 'rxjs/operators';
+import { UpdateStoreFormAction } from '../../lib/reducer';
 
 export class CustomUpdateAction implements Action {
   readonly type = 'CustomUpdateAction';
+}
+
+export class AddFormArrayItemAction implements Action {
+  readonly type = 'AddFormArrayItemAction';
 }
 
 @Component({
@@ -20,18 +24,40 @@ export class Form1ContainerComponent {
   formGroup: FormGroup;
   formState: Observable<FormGroupState>;
 
+  formArrayGroup: FormGroup;
+  formArrayState: Observable<FormGroupState>;
+
   constructor(private fb: FormBuilder, private store: Store<any>) {
     this.formGroup = fb.group({
       'name': ['', Validators.required],
       'userName': ['', Validators.required, (control: AbstractControl) => this.validateUserNameTaken(control)]
     });
     this.formState = store.select((state: any) => state.testForm.form1);
+
+    this.formArrayGroup = fb.group({
+      items: fb.array([])
+    });
+    this.formArrayState = store.select(state => state.testForm.form2);
+    // this
+    //   .formArrayState
+    //   .pipe(
+    //   filter(state => !!state && !!state.value && !!this.formArrayGroup)
+    //   )
+    //   .subscribe(result => {
+    //     const items = <any>result.value.items;
+    //     const controls = !!!items ? [] : items.map(item => {
+    //       return this.fb.group({
+    //         name: ['']
+    //       });
+    //     });
+    //     this.formArrayGroup.setControl('items', this.fb.array(controls));
+    //   });
   }
 
   validateUserNameTaken(control: AbstractControl) {
-    return of(control.value !== 'root' ? null : {userNameTaken: true})
+    return of(control.value !== 'root' ? null : { userNameTaken: true })
       .pipe(
-        delay(2000)
+      delay(2000)
       );
   }
 
@@ -43,5 +69,9 @@ export class Form1ContainerComponent {
 
   resetCustom() {
     this.store.dispatch(new CustomUpdateAction());
+  }
+
+  addFormArrayItem() {
+    this.store.dispatch(new AddFormArrayItemAction());
   }
 }


### PR DESCRIPTION
This branch contains an example of a form with a `formArray`. The idea is that if you click on `Add item to array` that a new item in the array is created an shown in the template.

Following is a screenshot of the `formArray` screen which I've added to test this case.
![image](https://user-images.githubusercontent.com/35688355/35723016-fcd8ba08-07f8-11e8-8be1-93b386f8f998.png)

There are a couple of issues here:

- When initally doing the `Add item to array` 4 actions get dispatched, I would expect less actions, at most 1, just a `FormArrayItemAction` ?:
![image](https://user-images.githubusercontent.com/35688355/35723838-0835633a-07fc-11e8-88df-4e30d1bd7064.png)
- After the first time 2 actions get dispatched:
![image](https://user-images.githubusercontent.com/35688355/35723962-6c7ab660-07fc-11e8-96cc-dc1c5754e5ac.png)
- FormGroupState.value should be generic because it expects [ k: string]: string;
- Now comes the biggest issue :) when you enable the commented code in `form1-container.component.ts` from line 41-54, then things really get bad. After this if you press the `Add item to array` button then a endless loop occurs.

