### PR TITLE
Fix #10: Spread operator in useValue of provider doesn't work when us…

### DIFF
--- a/src/lib/store-forms.module.ts
+++ b/src/lib/store-forms.module.ts
@@ -5,11 +5,15 @@ import {BindingDirective} from './binding.directive';
 import {Store} from '@ngrx/store';
 import {BindingService} from './binding.service';
 import {StoreFormsConfig} from './model';
-import { STORE_FORMS_CONFIG, STORE_FORMS_FEATURE } from './tokens';
+import {STORE_FORMS_CONFIG, _STORE_FORMS_CONFIG, STORE_FORMS_FEATURE} from './tokens';
 
 export const defaultStoreFormsConfig: StoreFormsConfig = {
   bindingStrategy: 'ObserveStore'
 };
+
+export function configFactory(config?: StoreFormsConfig): StoreFormsConfig {
+  return { ...defaultStoreFormsConfig, ...config };
+}
 
 @NgModule({
   imports: [
@@ -22,23 +26,19 @@ export const defaultStoreFormsConfig: StoreFormsConfig = {
   ],
   exports: [
     BindingDirective
-  ],
-  providers: [{
-    provide: STORE_FORMS_CONFIG,
-    useValue: defaultStoreFormsConfig
-  }, {
-    provide: BindingService,
-    useClass: BindingService,
-    deps: [STORE_FORMS_CONFIG, Store]
-  }]
+  ]
 })
 export class StoreFormsModule {
   static forRoot(config?: StoreFormsConfig): ModuleWithProviders {
     return {
       ngModule: StoreFormsModule,
       providers: [{
+        provide: _STORE_FORMS_CONFIG,
+        useValue: config
+      }, {
         provide: STORE_FORMS_CONFIG,
-        useValue: {...defaultStoreFormsConfig, ...config}
+        useFactory: configFactory,
+        deps: [_STORE_FORMS_CONFIG]
       }, {
         provide: BindingService,
         useClass: BindingService,
@@ -51,8 +51,12 @@ export class StoreFormsModule {
     return {
       ngModule: StoreFormsModule,
       providers: [{
+        provide: _STORE_FORMS_CONFIG,
+        useValue: config
+      }, {
         provide: STORE_FORMS_CONFIG,
-        useValue: {...defaultStoreFormsConfig, ...config}
+        useFactory: configFactory,
+        deps: [_STORE_FORMS_CONFIG]
       }, {
         provide: BindingService,
         useClass: BindingService,

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -2,4 +2,5 @@ import {InjectionToken} from '@angular/core';
 import {StoreFormsConfig} from './model';
 
 export const STORE_FORMS_CONFIG = new InjectionToken<StoreFormsConfig>('rxsf Config');
+export const _STORE_FORMS_CONFIG = new InjectionToken<StoreFormsConfig>('rxsf Config module');
 export const STORE_FORMS_FEATURE = new InjectionToken<string>('rxsf Feature');


### PR DESCRIPTION
This PR fixes #10 where the STORE_FORMS_CONFIG will be null when using AOT. Also removed the providers from the NgModule definition since the `forRoot` & `forFeature` convention is used.